### PR TITLE
Parameters don't split correctly

### DIFF
--- a/lib/chef/knife/cfn_create.rb
+++ b/lib/chef/knife/cfn_create.rb
@@ -57,7 +57,7 @@ class Chef
         :short => "-p 'key1=value1;key2=value2...'",
         :long => "--parameters 'key1=value1;key2=value2...'",
         :description => "Parameter values used to create the stack",
-        :proc => Proc.new { |parameters| parameters.split(',') }
+        :proc => Proc.new { |parameters| parameters.split(';') }
         
       option :timeout,
         :short => "-t TIMEOUT_VALUE",


### PR DESCRIPTION
Help says the parameters split on semicolon (;), but the split is on comma (,).
